### PR TITLE
Remove hard-coded NFC length for Nexus 5X

### DIFF
--- a/nfc/libnfc-brcm.conf
+++ b/nfc/libnfc-brcm.conf
@@ -402,3 +402,6 @@ NFA_PROPRIETARY_CFG={05:FF:FF:06:81:80:70:FF:FF}
 # Bail out mode
 #  If set to 1, NFCC is using bail out mode for either Type A or Type B poll.
 NFA_POLL_BAIL_OUT_MODE=0x01
+
+# Remove hard-coded NFC length
+ISO_DEP_MAX_TRANSCEIVE=0xFEFF


### PR DESCRIPTION
Extended length works perfectly with current LineageOs 15.1

Based on suggestion by @razorloves (https://forum.xda-developers.com/showpost.php?p=75948946&postcount=666)